### PR TITLE
Prevent memory overuse (VQD_DICT cache)

### DIFF
--- a/duckduckgo_search/utils.py
+++ b/duckduckgo_search/utils.py
@@ -42,6 +42,10 @@ def _get_vqd(keywords):
                 )
                 vqd = RE_VQD.search(resp.text).group(1)
                 if vqd:
+                    # delete the first key to reduce memory consumption (<699000 size 20Mb, >699_000 size 40Mb)
+                    if len(VQD_DICT) > 699_000:
+                        VQD_DICT.pop(next(iter(VQD_DICT)))
+                        
                     VQD_DICT[keywords] = vqd
                     logger.info("keywords=%s. Got vqd=%s", keywords, vqd)
                     return vqd

--- a/duckduckgo_search/utils.py
+++ b/duckduckgo_search/utils.py
@@ -44,8 +44,7 @@ def _get_vqd(keywords):
                 if vqd:
                     # delete the first key to reduce memory consumption (<699000 size 20Mb, >699_000 size 40Mb)
                     if len(VQD_DICT) > 699_000:
-                        VQD_DICT.pop(next(iter(VQD_DICT)))
-                        
+                        VQD_DICT.pop(next(iter(VQD_DICT)))                        
                     VQD_DICT[keywords] = vqd
                     logger.info("keywords=%s. Got vqd=%s", keywords, vqd)
                     return vqd

--- a/duckduckgo_search/utils.py
+++ b/duckduckgo_search/utils.py
@@ -44,7 +44,7 @@ def _get_vqd(keywords):
                 if vqd:
                     # delete the first key to reduce memory consumption (<699000 size 20Mb, >699_000 size 40Mb)
                     if len(VQD_DICT) > 699_000:
-                        VQD_DICT.pop(next(iter(VQD_DICT)))                        
+                        VQD_DICT.pop(next(iter(VQD_DICT)))
                     VQD_DICT[keywords] = vqd
                     logger.info("keywords=%s. Got vqd=%s", keywords, vqd)
                     return vqd


### PR DESCRIPTION
VQD_DICT - delete first key if len(VQD_DICT)>699000
```python3
from random import choice, randint
import objsize

with open("wordlist.10000") as wordfile:
    words = [x.rstrip() for x in wordfile]


for size in range(698_000, 710_000, 1_000):
    td = {f"{choice(words)}{randint(1_000_000_000, 9_999_999_999)}": "3-313604123259606289599999999542149999999-313604123259606289595796089749796290645" for i in range(size)}
    print(f"{len(td)=}", f"{size=}", int(objsize.get_exclusive_deep_size(td) / 1_048_576), "Mb")
```

```python3
len(td)=698000 size=698000 20 Mb
len(td)=699000 size=699000 20 Mb
len(td)=700000 size=700000 40 Mb
len(td)=701000 size=701000 40 Mb
len(td)=702000 size=702000 40 Mb
len(td)=703000 size=703000 40 Mb
len(td)=704000 size=704000 40 Mb
len(td)=705000 size=705000 40 Mb
len(td)=706000 size=706000 40 Mb
len(td)=707000 size=707000 40 Mb
len(td)=708000 size=708000 40 Mb
len(td)=709000 size=709000 40 Mb
```