### PR TITLE
updating file writing to handle forward '/' or back slashes '\' in ke…

### DIFF
--- a/duckduckgo_search/utils.py
+++ b/duckduckgo_search/utils.py
@@ -102,18 +102,31 @@ def _normalize(raw_html):
 
 
 def _do_output(module_name, keywords, output, results):
+
+    def get_file_name(extension):
+        return f"{module_name}_{keywords}_{datetime.now():%Y%m%d_%H%M%S}.{extension}"
+
     keywords = keywords.replace('"', "'")
+    # clean up forward and backward slash from keywords
+    # so filepath `open(...)` does not think there is a directory.
+    keywords = keywords.replace('/', "_").replace('/', "_")
+
+    filename = None
     if output == "csv":
-        _save_csv(
-            f"{module_name}_{keywords}_{datetime.now():%Y%m%d_%H%M%S}.csv", results
-        )
+        extension = "csv"
+        filename = get_file_name(extension)
     elif output == "json":
-        _save_json(
-            f"{module_name}_{keywords}_{datetime.now():%Y%m%d_%H%M%S}.json", results
-        )
+        extension = "json"
+        filename = get_file_name(extension)
     """
     elif output == "print":
         for i, result in enumerate(results, start=1):
             print(f"{i}.", json.dumps(result, ensure_ascii=False, indent=4))
             input()
     """
+    if filename is not None:
+        _save_json(
+            filename, results
+        )
+
+    return filename

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,47 @@
+import datetime
+import os
+import tempfile
+from unittest import mock
+
+from duckduckgo_search.utils import _do_output
+
+
+FAKE_TIME = datetime.datetime(2023, 1, 31, 7, 30, 0)
+
+
+@mock.patch("duckduckgo_search.utils.datetime")
+def test__do_output_query_without_slash(mock_datetime):
+    mock_datetime.now.return_value = FAKE_TIME
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # should write to disk successfully.
+        module_name = os.path.join(tmpdirname, 'ddg_module_name')
+
+        keywords = 'George Washington'
+        output = 'json'
+        results = {'a': 'b'}
+
+        expected_filepath = f"{module_name}_George Washington_20230131_073000.json"
+
+        output_location = _do_output(module_name, keywords, output,results)
+
+        assert output_location == expected_filepath
+
+
+@mock.patch("duckduckgo_search.utils.datetime")
+def test__do_output_query_with_slash(mock_datetime):
+    mock_datetime.now.return_value = FAKE_TIME
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # should write to disk successfully.
+        module_name = os.path.join(tmpdirname, 'ddg_module_name')
+
+        # query that should search specific sub-path of specific site.
+        keywords = 'George Washington site:"en.wikipedia.org/wiki/"'
+        output = 'json'
+        results = {'a': 'b'}
+
+        expected_filepath = f"{module_name}_George Washington site:'en.wikipedia.org_wiki_'_20230131_073000.json"
+        output_location = _do_output(module_name, keywords, output,results)
+
+        assert output_location == expected_filepath


### PR DESCRIPTION
- updating file writing to handle forward '/' or back slashes '\' in key words.
- added test to confirm error is not thrown on write to disk.

this PR fixes the error in Issue #44
