### PR TITLE
added date in default search results wherever available

### DIFF
--- a/duckduckgo_search/duckduckgo_search.py
+++ b/duckduckgo_search/duckduckgo_search.py
@@ -228,7 +228,7 @@ class DDGS:
                             "title": self._normalize(row["t"]),
                             "href": self._normalize_url(href),
                             "body": body,
-                            "date": row.get("e", None)
+                            "date": row.get("e", None),
                         }
             if result_exists is False:
                 break

--- a/duckduckgo_search/duckduckgo_search.py
+++ b/duckduckgo_search/duckduckgo_search.py
@@ -228,6 +228,7 @@ class DDGS:
                             "title": self._normalize(row["t"]),
                             "href": self._normalize_url(href),
                             "body": body,
+                            "date": row.get("e", None)
                         }
             if result_exists is False:
                 break


### PR DESCRIPTION
- Noticed that some past articles appeared in search results even after setting appropriate `timelimit`
- Added `date` in search results wherever available so that can utilize this field to filter out past results