### PR TITLE
Added verify parameter to AsyncDDGS and DDGS.

### DIFF
--- a/duckduckgo_search/duckduckgo_search.py
+++ b/duckduckgo_search/duckduckgo_search.py
@@ -8,8 +8,8 @@ logger = logging.getLogger("duckduckgo_search.DDGS")
 
 
 class DDGS(AsyncDDGS):
-    def __init__(self, headers=None, proxies=None, timeout=10):
-        super().__init__(headers, proxies, timeout)
+    def __init__(self, headers=None, proxies=None, timeout=10, verify=True):
+        super().__init__(headers, proxies, timeout, verify)
         self._loop = asyncio.new_event_loop()
 
     def __enter__(self) -> "DDGS":

--- a/duckduckgo_search/duckduckgo_search_async.py
+++ b/duckduckgo_search/duckduckgo_search_async.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import warnings
 import sys
 from collections import deque
 from datetime import datetime, timezone
@@ -16,7 +17,6 @@ from .exceptions import DuckDuckGoSearchException
 from .models import MapsResult
 from .utils import _extract_vqd, _is_500_in_url, _normalize, _normalize_url, _random_browser, _text_extract_json
 
-logging.basicConfig()
 logger = logging.getLogger("duckduckgo_search.AsyncDDGS")
 # Not working on Windows, NotImplementedError (https://curl-cffi.readthedocs.io/en/latest/faq/)
 if sys.platform.lower().startswith("win"):
@@ -39,9 +39,11 @@ class AsyncDDGS(metaclass=GoogleDocstringInheritanceMeta):
         self._asession = requests.AsyncSession(
             headers=headers, proxies=self.proxies, timeout=timeout, impersonate=_random_browser(), verify=verify
         )
-        logger.warning("AsyncDDGS verify flag set to False. HTTPS requests "
-                       "will not be verified. This is not recommended unless "
-                       "you are aware of the risks.")
+        if not verify:
+            warnings.warn(
+                "AsyncDDGS verify flag set to False. HTTPS requests "
+                "will not be verified. This is not recommended unless "
+                "you are aware of the risks.", UserWarning)
         self._asession.headers["Referer"] = "https://duckduckgo.com/"
 
     async def __aenter__(self) -> "AsyncDDGS":

--- a/duckduckgo_search/duckduckgo_search_async.py
+++ b/duckduckgo_search/duckduckgo_search_async.py
@@ -16,6 +16,7 @@ from .exceptions import DuckDuckGoSearchException
 from .models import MapsResult
 from .utils import _extract_vqd, _is_500_in_url, _normalize, _normalize_url, _random_browser, _text_extract_json
 
+logging.basicConfig()
 logger = logging.getLogger("duckduckgo_search.AsyncDDGS")
 # Not working on Windows, NotImplementedError (https://curl-cffi.readthedocs.io/en/latest/faq/)
 if sys.platform.lower().startswith("win"):
@@ -25,18 +26,22 @@ if sys.platform.lower().startswith("win"):
 class AsyncDDGS(metaclass=GoogleDocstringInheritanceMeta):
     """DuckDuckgo_search async class to get search results from duckduckgo.com."""
 
-    def __init__(self, headers=None, proxies=None, timeout=10) -> None:
+    def __init__(self, headers=None, proxies=None, timeout=10, verify=True) -> None:
         """Initialize the AsyncDDGS object.
 
         Args:
             headers (dict, optional): Dictionary of headers for the HTTP client. Defaults to None.
             proxies (Union[dict, str], optional): Proxies for the HTTP client (can be dict or str). Defaults to None.
             timeout (int, optional): Timeout value for the HTTP client. Defaults to 10.
+            verify  (bool, optional): Whether or not to verify HTTPS requests. Defaults to True.
         """
         self.proxies = proxies if proxies and isinstance(proxies, dict) else {"http": proxies, "https": proxies}
         self._asession = requests.AsyncSession(
-            headers=headers, proxies=self.proxies, timeout=timeout, impersonate=_random_browser()
+            headers=headers, proxies=self.proxies, timeout=timeout, impersonate=_random_browser(), verify=verify
         )
+        logger.warning("AsyncDDGS verify flag set to False. HTTPS requests "
+                       "will not be verified. This is not recommended unless "
+                       "you are aware of the risks.")
         self._asession.headers["Referer"] = "https://duckduckgo.com/"
 
     async def __aenter__(self) -> "AsyncDDGS":

--- a/tests/test_duckduckgo_search.py
+++ b/tests/test_duckduckgo_search.py
@@ -1,3 +1,6 @@
+import pytest
+import warnings
+
 from duckduckgo_search import DDGS
 
 
@@ -70,9 +73,15 @@ def test_translate():
     }
 
 
-def test_verify_warning(caplog):
-    DDGS(verify=False)
-    assert "WARNING" in caplog.text
+def test_verify_warning():
+    with pytest.warns(UserWarning, match="verify"):
+        DDGS(verify=False)
+
+
+def test_no_verify_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        DDGS()
 
 
 def test_verify_false_text():

--- a/tests/test_duckduckgo_search.py
+++ b/tests/test_duckduckgo_search.py
@@ -68,3 +68,14 @@ def test_translate():
         "translated": "Schule",
         "original": "school",
     }
+
+
+def test_verify_warning(caplog):
+    DDGS(verify=False)
+    assert "WARNING" in caplog.text
+
+
+def test_verify_false_text():
+    with DDGS(verify=False) as ddgs:
+        results = [x for x in ddgs.text("cat", max_results=30)]
+        assert len(results) == 30

--- a/tests/test_duckduckgo_search_async.py
+++ b/tests/test_duckduckgo_search_async.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from duckduckgo_search import AsyncDDGS
 
@@ -83,9 +84,15 @@ async def test_translate():
     }
 
 
-def test_verify_warning(caplog):
-    AsyncDDGS(verify=False)
-    assert "WARNING" in caplog.text
+def test_verify_warning():
+    with pytest.warns(UserWarning, match="verify"):
+        AsyncDDGS(verify=False)
+
+
+def test_no_verify_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        AsyncDDGS()
 
 
 @pytest.mark.asyncio

--- a/tests/test_duckduckgo_search_async.py
+++ b/tests/test_duckduckgo_search_async.py
@@ -81,3 +81,15 @@ async def test_translate():
         "translated": "Schule",
         "original": "school",
     }
+
+
+def test_verify_warning(caplog):
+    AsyncDDGS(verify=False)
+    assert "WARNING" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_verify_false_text():
+    async with AsyncDDGS(verify=False) as ddgs:
+        results = [x async for x in ddgs.text("cat", max_results=30)]
+        assert len(results) == 30


### PR DESCRIPTION
The verify flag allows for sending HTTPS requests that are not verified. It's useful when using certain proxy servers.

It has the same behavior as the verify parameter in [curl_cffi.requests.AsyncSession](https://curl-cffi.readthedocs.io/en/latest/api/curl_cffi.requests/#AsyncSession).

Because not verifying HTTPS requests can be dangerous, a warning message is displayed to the user if they set the flag to false.