### PR TITLE
Added option to get raw DuckDuckGo maps results.

### DIFF
--- a/duckduckgo_search/duckduckgo_search.py
+++ b/duckduckgo_search/duckduckgo_search.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Dict, Generator, Optional
+from typing import Dict, Generator, Optional, Union
 
 from .duckduckgo_search_async import AsyncDDGS
 
@@ -53,7 +53,7 @@ class DDGS(AsyncDDGS):
         async_gen = super().suggestions(*args, **kwargs)
         return self._iter_over_async(async_gen)
 
-    def maps(self, *args, **kwargs) -> Generator[Dict[str, Optional[str|int|float|list|dict]], None, None]:
+    def maps(self, *args, **kwargs) -> Generator[Dict[str, Optional[Union[str, int, float, list, dict]]], None, None]:
         async_gen = super().maps(*args, **kwargs)
         return self._iter_over_async(async_gen)
 

--- a/duckduckgo_search/duckduckgo_search.py
+++ b/duckduckgo_search/duckduckgo_search.py
@@ -53,7 +53,7 @@ class DDGS(AsyncDDGS):
         async_gen = super().suggestions(*args, **kwargs)
         return self._iter_over_async(async_gen)
 
-    def maps(self, *args, **kwargs) -> Generator[Dict[str, Optional[str]], None, None]:
+    def maps(self, *args, **kwargs) -> Generator[Dict[str, Optional[str|int|float|list|dict]], None, None]:
         async_gen = super().maps(*args, **kwargs)
         return self._iter_over_async(async_gen)
 

--- a/duckduckgo_search/duckduckgo_search_async.py
+++ b/duckduckgo_search/duckduckgo_search_async.py
@@ -6,7 +6,7 @@ from collections import deque
 from datetime import datetime, timezone
 from decimal import Decimal
 from itertools import cycle
-from typing import AsyncGenerator, Deque, Dict, Optional, Set, Tuple
+from typing import AsyncGenerator, Deque, Dict, Optional, Set, Tuple, Union
 
 from curl_cffi import requests
 from docstring_inheritance import GoogleDocstringInheritanceMeta
@@ -679,7 +679,7 @@ class AsyncDDGS(metaclass=GoogleDocstringInheritanceMeta):
         radius: int = 0,
         max_results: Optional[int] = None,
         raw_results: bool = False,
-    ) -> AsyncGenerator[Dict[str, Optional[str|int|float|list|dict]], None]:
+    ) -> AsyncGenerator[Dict[str, Optional[Union[str, int, float, list, dict]]], None]:
         """DuckDuckGo maps search. Query params: https://duckduckgo.com/params.
 
         Args:

--- a/duckduckgo_search/duckduckgo_search_async.py
+++ b/duckduckgo_search/duckduckgo_search_async.py
@@ -697,7 +697,7 @@ class AsyncDDGS(metaclass=GoogleDocstringInheritanceMeta):
             radius: expand the search square by the distance in kilometers. Defaults to 0.
             max_results: max number of results. If None, returns results only from the first response. Defaults to None.
             raw_results: if True, returns results in the same format as the DuckDuckGo API. Otherwise,
-                the result dicts are returned with the same structure as the MapsResults class.
+                the result dicts are returned with the same structure as the MapsResults class. Defaults to False.
 
         Yields:
             dict with maps search results

--- a/duckduckgo_search/duckduckgo_search_async.py
+++ b/duckduckgo_search/duckduckgo_search_async.py
@@ -679,7 +679,7 @@ class AsyncDDGS(metaclass=GoogleDocstringInheritanceMeta):
         radius: int = 0,
         max_results: Optional[int] = None,
         raw_results: bool = False,
-    ) -> AsyncGenerator[Dict[str, Optional[str]], None]:
+    ) -> AsyncGenerator[Dict[str, Optional[str|int|float|list|dict]], None]:
         """DuckDuckGo maps search. Query params: https://duckduckgo.com/params.
 
         Args:

--- a/tests/test_duckduckgo_search.py
+++ b/tests/test_duckduckgo_search.py
@@ -1,4 +1,7 @@
+import pytest
+
 from duckduckgo_search import DDGS
+from duckduckgo_search.models import MapsResult
 
 
 def test_text():
@@ -47,6 +50,22 @@ def test_maps():
     with DDGS() as ddgs:
         results = [x for x in ddgs.maps("school", place="London", max_results=30)]
         assert len(results) == 30
+
+
+def test_maps_structured_results():
+    with DDGS() as ddgs:
+        results = [x for x in ddgs.maps("school", place="London", max_results=30)]
+        for res in results:
+            MapsResult(**res)
+
+
+def test_maps_raw_results():
+    with DDGS() as ddgs:
+        results = [x for x in ddgs.maps("school", place="London", max_results=30, raw_results=True)]
+        for res in results:
+            with pytest.raises(TypeError) as excinfo:
+                MapsResult(**res)
+            assert "unexpected keyword argument" in str(excinfo.value)
 
 
 def test_answers():

--- a/tests/test_duckduckgo_search_async.py
+++ b/tests/test_duckduckgo_search_async.py
@@ -1,6 +1,7 @@
 import pytest
 
 from duckduckgo_search import AsyncDDGS
+from duckduckgo_search.models import MapsResult
 
 
 @pytest.mark.asyncio
@@ -57,6 +58,24 @@ async def test_maps():
     async with AsyncDDGS() as ddgs:
         results = [x async for x in ddgs.maps("school", place="London", max_results=30)]
         assert len(results) == 30
+
+
+@pytest.mark.asyncio
+async def test_maps_structured_results():
+    async with AsyncDDGS() as ddgs:
+        results = [x async for x in ddgs.maps("school", place="London", max_results=30)]
+        for res in results:
+            MapsResult(**res)
+
+
+@pytest.mark.asyncio
+async def test_maps_raw_results():
+    async with AsyncDDGS() as ddgs:
+        results = [x async for x in ddgs.maps("school", place="London", max_results=30, raw_results=True)]
+        for res in results:
+            with pytest.raises(TypeError) as excinfo:
+                MapsResult(**res)
+            assert "unexpected keyword argument" in str(excinfo.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Currently, when using DDGS.maps() or AsyncDDGS.maps(), the raw map results from DuckDuckGo are restructured according to the MapsResult model and then returned to the user as a dictionary. I added a raw_results boolean parameter to the AsyncDDGS.maps() method that allows for the raw map results to be returned. The parameter defaults to False so as to keep the library backwards compatible.

I am currently working on a use case where I need to access ratings, reviews, and other information that is provided in the raw DDG results, but not in the structured results currently being returned by the library. Instead of changing the MapsResult model, I think it would be best to allow the user to get the raw results (which is what a few other AsyncDDGS methods already return) and structure them as they wish.

Testing is in place to make sure the default use of the maps method (with raw_results set to False) returns results that satisfy the MapsResult model.