### PR TITLE
DDGS: using asyncio.run instead of manipulating the loops

### DIFF
--- a/duckduckgo_search/duckduckgo_search.py
+++ b/duckduckgo_search/duckduckgo_search.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import warnings
 from typing import Dict, Generator, Optional
 
 import nest_asyncio
@@ -8,30 +7,24 @@ import nest_asyncio
 from .duckduckgo_search_async import AsyncDDGS
 
 logger = logging.getLogger("duckduckgo_search.DDGS")
+nest_asyncio.apply()
 
 
 class DDGS(AsyncDDGS):
     def __init__(self, headers=None, proxies=None, timeout=10):
         super().__init__(headers, proxies, timeout)
-        if asyncio.get_event_loop().is_running():
-            nest_asyncio.apply()
-            warnings.warn("DDGS running in an async loop. This may cause errors. Use AsyncDDGS instead.", stacklevel=2)
-            self._loop = asyncio.get_running_loop()
-        else:
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
 
     def __enter__(self) -> "DDGS":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        self._loop.run_until_complete(self.__aexit__(exc_type, exc_val, exc_tb))
+        asyncio.run(super().__aexit__(exc_type, exc_val, exc_tb))
 
     def _iter_over_async(self, async_gen):
         """Iterate over an async generator."""
         while True:
             try:
-                yield self._loop.run_until_complete(async_gen.__anext__())
+                yield asyncio.run(async_gen.__anext__())
             except StopAsyncIteration:
                 break
 
@@ -65,4 +58,4 @@ class DDGS(AsyncDDGS):
 
     def translate(self, *args, **kwargs) -> Optional[Dict[str, Optional[str]]]:
         async_coro = super().translate(*args, **kwargs)
-        return self._loop.run_until_complete(async_coro)
+        return asyncio.run(async_coro)


### PR DESCRIPTION
Just using nest_asyncio.apply() and asyncio.run() to get around various problems.