### PR TITLE
Optimize package size: make lxml optional and orjson mandatory

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,8 @@ jobs:
         ruff format . --check --target-version py38
     - name: Mypy
       run: |
-        python -m pip install orjson
+        python -m pip install .
+        python -m pip install .[lxml]
         mypy --install-types .
     - name: Pytest
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Search for words, documents, images, videos, news, maps and text translation usi
 ```python
 pip install -U duckduckgo_search
 ```
-> :point_up: `duckduckgo_search` also uses `orjson` if it is installed.
+**[Optional]** To use the `text` function with `backend='html'` or `backend='lite'`:
+```python
+pip install -U duckduckgo_search[lxml]
+```
 
 ## CLI version
 

--- a/duckduckgo_search/utils.py
+++ b/duckduckgo_search/utils.py
@@ -1,4 +1,3 @@
-import json
 import re
 from decimal import Decimal
 from html import unescape
@@ -6,28 +5,23 @@ from math import atan2, cos, radians, sin, sqrt
 from typing import Any, Dict, List, Union
 from urllib.parse import unquote
 
-from .exceptions import DuckDuckGoSearchException
+import orjson
 
-try:
-    import orjson
-except ModuleNotFoundError:
-    HAS_ORJSON = False
-else:
-    HAS_ORJSON = True
+from .exceptions import DuckDuckGoSearchException
 
 REGEX_STRIP_TAGS = re.compile("<.*?>")
 
 
 def json_dumps(obj: Any) -> str:
     try:
-        return orjson.dumps(obj).decode("utf-8") if HAS_ORJSON else json.dumps(obj)
+        return orjson.dumps(obj).decode("utf-8")
     except Exception as ex:
         raise DuckDuckGoSearchException(f"{type(ex).__name__}: {ex}") from ex
 
 
 def json_loads(obj: Union[str, bytes]) -> Any:
     try:
-        return orjson.loads(obj) if HAS_ORJSON else json.loads(obj)
+        return orjson.loads(obj)
     except Exception as ex:
         raise DuckDuckGoSearchException(f"{type(ex).__name__}: {ex}") from ex
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "click>=8.1.7",    
     "curl_cffi>=0.6.2",
-    "lxml>=5.1.0",
+    "orjson>=3.9.15",
 ]
 dynamic = ["version"]
 
@@ -44,6 +44,9 @@ ddgs = "duckduckgo_search.cli:cli"
 version = {attr = "duckduckgo_search.version.__version__"}
 
 [project.optional-dependencies]
+lxml = [
+    "lxml>=5.1.0",
+]
 dev = [
     "mypy>=1.8.0",
     "pytest>=8.0.1",


### PR DESCRIPTION
1. make lxml optional (used only in def text() with backend='html' or 'lite', but is large)
2. make orjson mandatory (has a very small disk size)