### PR TITLE
Chat interface updates - new flags for multi-line input, model choice selection, updated paragraph wrapping for output and option flag to disable, and minor bugfixes

### DIFF
--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -170,8 +170,9 @@ def chat(save, proxy):
         retries = retry_default
         while retries > 0:
             resp_answer = client.chat(keywords=user_input, model=model)
-            text = click.wrap_text(resp_answer, width=78, preserve_paragraphs=True)
-            click.secho(f"AI: {text}", bg="black", fg="green", overline=False)
+            text = '\n'.join([click.wrap_text(paragraph, width=78, preserve_paragraphs=True) \
+                    for paragraph in resp_answer.split('\n')])
+            click.secho(f"AI:\n{text}", bg="black", fg="green", overline=False)
             if resp_answer:
                 break
 

--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -135,7 +135,8 @@ def version():
 @cli.command()
 @click.option("-s", "--save", is_flag=True, default=False, help="save the conversation in the json file")
 @click.option("-p", "--proxy", default=None, help="the proxy to send requests, example: socks5://localhost:9150")
-def chat(save, proxy):
+@click.option("-w", "--disable-wrapping", is_flag=True, default=False, help="disable paragraph wrapping for output")
+def chat(save, proxy, disable_wrapping):
     """CLI function to perform an interactive AI chat using DuckDuckGo API."""
     cache_file = "ddgs_chat_conversation.json"
     models = ["gpt-3.5", "claude-3-haiku", "llama-3-70b", "mixtral-8x7b"]
@@ -171,7 +172,7 @@ def chat(save, proxy):
         while retries > 0:
             resp_answer = client.chat(keywords=user_input, model=model)
             text = '\n'.join([click.wrap_text(paragraph, width=78, preserve_paragraphs=True) \
-                    for paragraph in resp_answer.split('\n')])
+                    for paragraph in resp_answer.split('\n')]) if not disable_wrapping else resp_answer
             click.secho(f"AI:\n{text}", bg="black", fg="green", overline=False)
             if resp_answer:
                 break

--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -144,9 +144,13 @@ def chat(save, proxy):
     print("DuckDuckGo AI chat. Available models:")
     for idx, model in enumerate(models, start=1):
         print(f"{idx}. {model}")
-    chosen_model_idx = input("Choose a model by entering its number[1]: ")
-    chosen_model_idx = 0 if not chosen_model_idx.strip() else int(chosen_model_idx) - 1
-    model = models[chosen_model_idx]
+    try:
+        chosen_model_idx = input("Choose a model by entering its number[1]: ")
+        chosen_model_idx = 0 if not chosen_model_idx.strip() else int(chosen_model_idx) - 1
+        model = models[chosen_model_idx]
+    except (IndexError, ValueError) as e:
+        print(f"'{chosen_model_idx}' is not a valid model index\n{e}")
+        return
     print(f"Using model: {model}")
 
     if save and Path(cache_file).exists():

--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -164,7 +164,8 @@ def chat(save, proxy):
         click.secho(f"AI: {text}", bg="black", fg="green", overline=True)
 
         cache = {"vqd": client._chat_vqd, "messages": client._chat_messages}
-        _save_json(cache_file, cache)
+        if save:
+            _save_json(cache_file, cache)
 
         if "exit" in user_input.lower() or "quit" in user_input.lower():
             break


### PR DESCRIPTION
Following on the inspiration to share back to the community from PR 227, I offer these improvements.
The commit messages should have most of the info there. 
I did modify/comment out this line
text = resp_answer #click.wrap_text(resp_answer, width=78, preserve_paragraphs=True)
since the formatted text returned does look right when it prints mardown code.

Let me know what you think.