### PR TITLE
Allow specifying output filename in CLI

### DIFF
--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -186,14 +186,13 @@ def chat(load, proxy, multiline, timeout, verify, model):
 @click.option("-s", "--safesearch", default="moderate", type=click.Choice(["on", "moderate", "off"]))
 @click.option("-t", "--timelimit", default=None, type=click.Choice(["d", "w", "m", "y"]), help="day, week, month, year")
 @click.option("-m", "--max_results", default=20, help="maximum number of results, default=20")
-@click.option("-o", "--output", default="print", help="csv, json (save the results to a csv or json file)")
-@click.option("-f", "--filename", default=None, help="specify the file name (without extension) to save the results")
+@click.option("-o", "--output", default="print", help="csv, json (save the results to a csv or json file). optionally specify the full filename")
 @click.option("-d", "--download", is_flag=True, default=False, help="download results to 'keywords' folder")
 @click.option("-b", "--backend", default="api", type=click.Choice(["api", "html", "lite"]), help="which backend to use")
 @click.option("-th", "--threads", default=10, help="download threads, default=10")
 @click.option("-p", "--proxy", default=None, help="the proxy to send requests, example: socks5://127.0.0.1:9150")
 @click.option("-v", "--verify", default=True, help="verify SSL when making the request")
-def text(keywords, region, safesearch, timelimit, backend, output, filename, download, threads, max_results, proxy, verify):
+def text(keywords, region, safesearch, timelimit, backend, output, download, threads, max_results, proxy, verify):
     """CLI function to perform a text search using DuckDuckGo API."""
     data = DDGS(proxy=_expand_proxy_tb_alias(proxy), verify=verify).text(
         keywords=keywords,
@@ -204,12 +203,16 @@ def text(keywords, region, safesearch, timelimit, backend, output, filename, dow
         max_results=max_results,
     )
     keywords = _sanitize_keywords(keywords)
-    filename = filename if filename else f"text_{keywords}_{datetime.now():%Y%m%d_%H%M%S}"
+    if output.endswith(".json") or output.endswith(".csv"):
+        filename = output.rsplit(".", 1)[0]
+    else:
+        filename = f"text_{keywords}_{datetime.now():%Y%m%d_%H%M%S}"
+
     if output == "print" and not download:
         _print_data(data)
-    elif output == "csv":
+    elif output == "csv" or output.endswith(".csv"):
         _save_csv(f"{filename}.csv", data)
-    elif output == "json":
+    elif output == "json" or output.endswith(".json"):
         _save_json(f"{filename}.json", data)
     if download:
         _download_results(keywords, data, proxy=proxy, threads=threads, verify=verify)

--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -187,12 +187,13 @@ def chat(load, proxy, multiline, timeout, verify, model):
 @click.option("-t", "--timelimit", default=None, type=click.Choice(["d", "w", "m", "y"]), help="day, week, month, year")
 @click.option("-m", "--max_results", default=20, help="maximum number of results, default=20")
 @click.option("-o", "--output", default="print", help="csv, json (save the results to a csv or json file)")
+@click.option("-f", "--filename", default=None, help="specify the file name (without extension) to save the results")
 @click.option("-d", "--download", is_flag=True, default=False, help="download results to 'keywords' folder")
 @click.option("-b", "--backend", default="api", type=click.Choice(["api", "html", "lite"]), help="which backend to use")
 @click.option("-th", "--threads", default=10, help="download threads, default=10")
 @click.option("-p", "--proxy", default=None, help="the proxy to send requests, example: socks5://127.0.0.1:9150")
 @click.option("-v", "--verify", default=True, help="verify SSL when making the request")
-def text(keywords, region, safesearch, timelimit, backend, output, download, threads, max_results, proxy, verify):
+def text(keywords, region, safesearch, timelimit, backend, output, filename, download, threads, max_results, proxy, verify):
     """CLI function to perform a text search using DuckDuckGo API."""
     data = DDGS(proxy=_expand_proxy_tb_alias(proxy), verify=verify).text(
         keywords=keywords,
@@ -203,7 +204,7 @@ def text(keywords, region, safesearch, timelimit, backend, output, download, thr
         max_results=max_results,
     )
     keywords = _sanitize_keywords(keywords)
-    filename = f"text_{keywords}_{datetime.now():%Y%m%d_%H%M%S}"
+    filename = filename if filename else f"text_{keywords}_{datetime.now():%Y%m%d_%H%M%S}"
     if output == "print" and not download:
         _print_data(data)
     elif output == "csv":

--- a/duckduckgo_search/cli.py
+++ b/duckduckgo_search/cli.py
@@ -180,21 +180,6 @@ def chat(load, proxy, multiline, timeout, verify, model):
             _save_json(cache_file, cache)
 
 
-class Union(click.ParamType):
-    def __init__(self, types, name="Union"):
-        self.types = types
-        self.name = name
-    
-    def convert(self, value, param, ctx):
-        for type in self.types:
-            try:
-                return type.convert(value, param, ctx)
-            except click.BadParameter:
-                continue
-        
-        self.fail("Parameter is not valid")
-
-
 @cli.command()
 @click.option("-k", "--keywords", required=True, help="text search, keywords for query")
 @click.option("-r", "--region", default="wt-wt", help="wt-wt, us-en, ru-ru, etc. -region https://duckduckgo.com/params")
@@ -203,10 +188,7 @@ class Union(click.ParamType):
 @click.option("-m", "--max_results", default=20, help="maximum number of results, default=20")
 @click.option("-o", "--output", default="print",
               help="csv, json (save the results to a csv or json file). optionally specify the full filename",
-              type=Union(
-                  [click.Choice(["print", "csv", "json"]), click.Path(file_okay=True, dir_okay=False, writable=True)],
-                  name="output")
-              )
+              type=click.Path(file_okay=True, dir_okay=False, writable=True))
 @click.option("-d", "--download", is_flag=True, default=False, help="download results to 'keywords' folder")
 @click.option("-b", "--backend", default="api", type=click.Choice(["api", "html", "lite"]), help="which backend to use")
 @click.option("-th", "--threads", default=10, help="download threads, default=10")


### PR DESCRIPTION
The option specifies the file name (without extension) to save the results. Only takes effect if --output is csv or json.

Example: `ddgs text -k "query" -o json -f "search_results"` saves the results to `search_results.json`.

It's useful for workflows where the user needs to access a predetermined file name instead of an auto-generated one.